### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/gerador_senha.py
+++ b/gerador_senha.py
@@ -1,8 +1,10 @@
 import random
 import string
+import logging
 from flask import Flask, render_template, request, jsonify
 
 app = Flask(__name__)
+app.logger.setLevel(logging.ERROR)
 
 class PasswordGenerator:
     def __init__(self):
@@ -71,7 +73,8 @@ def gerar_senha():
         return jsonify(result)
         
     except Exception as e:
-        return jsonify({'error': f'Erro ao gerar senha: {str(e)}'})
+        app.logger.error(f"Erro ao gerar senha: {str(e)}")
+        return jsonify({'error': 'Erro interno ao gerar senha.'})
 
 if __name__ == '__main__':
     app.run(debug=True, host='127.0.0.1', port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/Delean-Mafra/Delean-Mafra/security/code-scanning/5](https://github.com/Delean-Mafra/Delean-Mafra/security/code-scanning/5)

To fix the issue, we will replace the detailed error message returned to the user with a generic one. The detailed exception information will instead be logged on the server. This ensures that developers can still debug issues using the logs, but sensitive information is not exposed to end users.

Steps to implement the fix:
1. Replace the `return jsonify({'error': f'Erro ao gerar senha: {str(e)}'})` statement with a generic error message like `return jsonify({'error': 'Erro interno ao gerar senha.'})`.
2. Log the exception details (`str(e)`) on the server using Python's `logging` module.
3. Add the necessary import for the `logging` module and configure basic logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
