### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/fechar_programas_pasta.py
+++ b/fechar_programas_pasta.py
@@ -73,6 +73,11 @@ def verificar_processos():
     if not caminho_pasta:
         return jsonify({'error': 'Caminho da pasta é obrigatório'}), 400
     
+    safe_root = '/safe/root/directory'
+    caminho_pasta = os.path.abspath(caminho_pasta)
+    if not caminho_pasta.startswith(safe_root):
+        return jsonify({'error': 'Caminho da pasta não é permitido'}), 400
+    
     if not os.path.exists(caminho_pasta):
         return jsonify({'error': 'Caminho da pasta não existe'}), 400
     


### PR DESCRIPTION
Potential fix for [https://github.com/Delean-Mafra/Delean-Mafra/security/code-scanning/7](https://github.com/Delean-Mafra/Delean-Mafra/security/code-scanning/7)

To fix the issue, we need to validate the `caminho_pasta` variable to ensure it is within a predefined safe directory. This can be achieved by:
1. Defining a safe root directory (e.g., `/safe/root/directory`).
2. Normalizing the user-provided path using `os.path.abspath` or `os.path.normpath`.
3. Verifying that the normalized path starts with the safe root directory.

This approach ensures that even if the user provides a malicious path (e.g., `../../../etc/passwd`), it will not escape the safe root directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
